### PR TITLE
Add docker option for building and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ make
 To build the plugin, Go version 1.16 or higher is required. The resulting plugin binary will be written to `./build/bin`.
 Copy the either extracted or built plugin binary to a location of your choice (e.g. /usr/local/bin/telegraf/).
 
+### Run / Build via Docker
+If the plugin is not available for your desired target platform (e.g. for your Rapberry Pi), you can still build and run it using Docker, regardless of whether Telegraf is installed on your machine. To do this, simply execute the corresponding script in the /docker/ directory.
+
+For building the plugin, run the docker-build.sh script. Before executing, you might need to make the script executable with the command chmod +x docker-build.sh. To start the plugin, use the docker-run.sh script, making it executable if necessary with chmod +x docker-run.sh.
+
+Before starting, ensure to customize the two configuration files located in the /docker/config/ directory according to your needs.
+
 ### Configuration
 This is an [external plugin](https://github.com/influxdata/telegraf/blob/master/docs/EXTERNAL_PLUGINS.md) which has to be integrated via Telegraf's [excecd plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/execd).
 

--- a/docker/config/fritzbox.conf
+++ b/docker/config/fritzbox.conf
@@ -1,0 +1,27 @@
+[[inputs.fritzbox]]
+  ## The fritz devices to query (multiple triples of base url, login, password)
+  devices = [["http://fritz.box:49000", "<username>", "<password>"]]
+  ## The http timeout to use (in seconds)
+  timeout = 5
+  ## Skip TLS verification (insecure)
+  tls_skip_verify = false
+  ## Process Device services (if found)
+  get_device_info = true
+  ## Process WLAN services (if found)
+  get_wlan_info = true
+  ## Process WAN services (if found)
+  get_wan_info = true
+  ## Process DSL services (if found)
+  get_dsl_info = true
+  ## Process PPP services (if found)
+  get_ppp_info = true
+  ## Process Mesh infos for selected hosts (must be one of the hosts defined in devices)
+  # get_mesh_info = []
+  ## Get all mesh clients from mesh info
+  # get_mesh_clients = false
+  ## The type of mesh clients to report (WLAN, LAN; empty list reports all)
+  # mesh_client_types = ["WLAN"]
+  ## The cycle count, at which low-traffic stats are queried
+  # full_query_cycle = 6
+  ## Enable debug output
+  debug = true

--- a/docker/config/telegraf.conf
+++ b/docker/config/telegraf.conf
@@ -1,0 +1,166 @@
+# Telegraf Configuration
+
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+
+# Global tags can be specified here in key="value" format.
+[global_tags]
+  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
+  # rack = "1a"
+  ## Environment variables can be used as tags, and throughout the config file
+  # user = "$USER"
+
+# Configuration for telegraf agent
+[agent]
+  ## Override default hostname, if empty use os.Hostname()
+  hostname = "fritzbox-telegraf"
+  ## If set to true, do no set the "host" tag in the telegraf agent.
+  omit_hostname = false
+  ## Default data collection interval for all inputs
+  interval = "10s"
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  ## Telegraf will send metrics to outputs in batches of at most
+  ## metric_batch_size metrics.
+  ## This controls the size of writes that Telegraf sends to output plugins.
+  metric_batch_size = 1000
+
+  ## Maximum number of unwritten metrics per output.  Increasing this value
+  ## allows for longer periods of output downtime without dropping metrics at the
+  ## cost of higher maximum memory usage.
+  metric_buffer_limit = 10000
+
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  ## Collection offset is used to shift the collection by the given amount.
+  ## This can be be used to avoid many plugins querying constraint devices
+  ## at the same time by manually scheduling them in time.
+  # collection_offset = "0s"
+
+  ## Default flushing interval for all outputs. Maximum flush_interval will be
+  ## flush_interval + flush_jitter
+  flush_interval = "10s"
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  ## Collected metrics are rounded to the precision specified. Precision is
+  ## specified as an interval with an integer + unit (e.g. 0s, 10ms, 2us, 4s).
+  ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+  ##
+  ## By default or when set to "0s", precision will be set to the same
+  ## timestamp order as the collection interval, with the maximum being 1s:
+  ##   ie, when interval = "10s", precision will be "1s"
+  ##       when interval = "250ms", precision will be "1ms"
+  ##
+  ## Precision will NOT be used for service inputs. It is up to each individual
+  ## service input to set the timestamp at the appropriate precision.
+  precision = "0s"
+
+  ## Log at debug level.
+  # debug = false
+  ## Log only error level messages.
+  # quiet = false
+
+  ## Log target controls the destination for logs and can be one of "file",
+  ## "stderr" or, on Windows, "eventlog".  When set to "file", the output file
+  ## is determined by the "logfile" setting.
+  # logtarget = "file"
+
+  ## Name of the file to be logged to when using the "file" logtarget.  If set to
+  ## the empty string then logs are written to stderr.
+  # logfile = ""
+
+  ## The logfile will be rotated after the time interval specified.  When set
+  ## to 0 no time based rotation is performed.  Logs are rotated only when
+  ## written to, if there is no log activity rotation may be delayed.
+  # logfile_rotation_interval = "0h"
+
+  ## The logfile will be rotated when it becomes larger than the specified
+  ## size.  When set to 0 no size based rotation is performed.
+  # logfile_rotation_max_size = "0MB"
+
+  ## Maximum number of rotated archives to keep, any older logs are deleted.
+  ## If set to -1, no archives are removed.
+  # logfile_rotation_max_archives = 5
+
+  ## Pick a timezone to use when logging or type 'local' for local time.
+  ## Example: America/Chicago
+  # log_with_timezone = ""
+
+  ## Method of translating SNMP objects. Can be "netsnmp" which
+  ## translates by calling external programs snmptranslate and snmptable,
+  ## or "gosmi" which translates using the built-in gosmi library.
+  # snmp_translator = "netsnmp"
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+
+# # Configuration for sending metrics to InfluxDB 2.0
+[[outputs.influxdb_v2]]
+#   ## The URLs of the InfluxDB cluster nodes.
+#   ##
+#   ## Multiple URLs can be specified for a single cluster, only ONE of the
+#   ## urls will be written to each interval.
+#   ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
+   urls = ["http://<url-to-your-influx-instance>:8086"]
+#
+#   ## Token for authentication.
+   token = "<influx-token>"
+#
+#   ## Organization is the name of the organization you wish to write to.
+   organization = "<influx-org>"
+#
+#   ## Destination bucket to write into.
+   bucket = "<influx-bucket>"
+#
+#   ## The value of this tag will be used to determine the bucket.  If this
+#   ## tag is not set the 'bucket' option is used as the default.
+#   # bucket_tag = ""
+#
+#   ## If true, the bucket tag will not be added to the metric.
+#   # exclude_bucket_tag = false
+#
+#   ## Timeout for HTTP messages.
+#   # timeout = "5s"
+#
+#   ## Additional HTTP headers
+#   # http_headers = {"X-Special-Header" = "Special-Value"}
+#
+#   ## HTTP Proxy override, if unset values the standard proxy environment
+#   ## variables are consulted to determine which proxy, if any, should be used.
+#   # http_proxy = "http://corporate.proxy:3128"
+#
+#   ## HTTP User-Agent
+#   # user_agent = "telegraf"
+#
+#   ## Content-Encoding for write request body, can be set to "gzip" to
+#   ## compress body or "identity" to apply no encoding.
+#   # content_encoding = "gzip"
+#
+#   ## Enable or disable uint support for writing uints influxdb 2.0.
+#   # influx_uint_support = false
+#
+#   ## Optional TLS Config for use on HTTP connections.
+#   # tls_ca = "/etc/telegraf/ca.pem"
+#   # tls_cert = "/etc/telegraf/cert.pem"
+#   # tls_key = "/etc/telegraf/key.pem"
+#   ## Use TLS but skip chain & host verification
+#   # insecure_skip_verify = false
+
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+[[inputs.execd]]
+  command = ["/opt/plugin-binary/fritzbox-telegraf-plugin", "-config", "/etc/telegraf/fritzbox.conf", "-poll_interval", "10s"]
+  signal = "none"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -1,0 +1,9 @@
+
+# This will build the plugin binary and copy it to the plugin-binary folder
+docker run --rm -v $(pwd)/plugin-binary:/opt/plugin-binary/ golang:1.22 bash -c "\
+    mkdir /opt/fritzbox-telegraf && \
+    git clone https://github.com/vlorian-de/fritzbox-telegraf-plugin.git /opt/fritzbox-telegraf && \
+    cd /opt/fritzbox-telegraf && \
+    make && \
+    cp build/bin/fritzbox-telegraf-plugin /opt/plugin-binary/fritzbox-telegraf-plugin && \
+    chmod + x /opt/plugin-binary/fritzbox-telegraf-plugin"

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -1,0 +1,11 @@
+# This will run the telegraf container with the plugin binary and the configurations from the docker/config folder
+echo "Starting telegraf container"
+echo "Make sure to have adapted the conf files in docker/config/ to your environment"
+docker run \
+    --name fritzbox-telegraf \
+    --restart unless-stopped \
+    -d \
+    -v $(pwd)/plugin-binary:/opt/plugin-binary/:ro \
+    -v $(pwd)/config:/etc/telegraf/:ro \
+    -it \
+    telegraf


### PR DESCRIPTION
Hallo,
vielen lieben Dank, dass du dieses nützliche Plugin geschrieben hast.
Da ich die meisten Services inzwischen containerisiert laufen lasse, habe ich 2 Skripte geschrieben um dein Plugin sowohl in einem Container zu bauen und auch in einem Container auszuführen.

Das Bauen im Container ist für die Leute interessant, die noch keine Golang-Umgebung aufgesetzt haben. So müssen sie zum Bauen nichts installieren und der Container löscht sich nach erfolgreichem Bauen auch wieder ganz von alleine. 

Das Ausführen im Container ist für Leute interessant, die die Fritzbox-Daten mit einem eigenen Hostname wegloggen möchten. Das Docker-Run-Skript macht dein Plugin quasi standalone lauffähig und so kann man fürs Loggen einen eigenen Hostname wählen und das Plugin auch auf Maschinen nutzen auf denen noch keine Telegraf installiert ist.

Es wäre mir eine Ehre, wenn meine Skripte es in dein Repo schaffen würden.

Viele Grüße
Vlorian